### PR TITLE
031 - [ADD] PBI32 & Refactor PBI31

### DIFF
--- a/backend/src/main/java/com/example/backend/services/OrderService.java
+++ b/backend/src/main/java/com/example/backend/services/OrderService.java
@@ -11,6 +11,8 @@ import com.example.backend.repositories.CartRepository;
 import com.example.backend.repositories.OrderRepository;
 import com.example.backend.repositories.SaleItemRepository;
 import com.example.backend.repositories.UserRepository;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -20,12 +22,12 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.server.ResponseStatusException;
 
 import java.math.BigDecimal;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Objects;
+import java.util.*;
 
 @Service
 public class OrderService {
+    private static final Logger log = LoggerFactory.getLogger(OrderService.class);
+
     @Autowired
     private OrderRepository orderRepo;
     @Autowired
@@ -44,54 +46,108 @@ public class OrderService {
         }
         User buyer = userRepo.findById(req.getBuyerId().intValue())
                 .orElseThrow(() -> new ItemNotFoundException("Buyer not found with id: " + req.getBuyerId()));
+
         List<OrderDto.PlaceOrderResponse> responses = new ArrayList<>();
-        List<Integer> allSelectedSaleItemIds = new ArrayList<>();
+        List<Integer> successfullyOrderedSaleItemIds = new ArrayList<>();
+
         for (OrderDto.SellerOrderGroup group : req.getSellerGroups()) {
             User seller = userRepo.findById(group.getSellerId().intValue())
                     .orElseThrow(() -> new ItemNotFoundException("Seller not found with id: " + group.getSellerId()));
+
+            boolean hasInsufficientStock = false;
+            String insufficientItemModel = null;
+            Map<Long, SaleItem> fetchedSaleItems = new HashMap<>();
+
+            log.info("Checking stock for seller {}", seller.getId());
+            for (OrderDto.SelectedCartItem itemRequest : group.getItems()) {
+                SaleItem saleItem = fetchedSaleItems.computeIfAbsent(itemRequest.getSaleItemId(),
+                        id -> saleItemRepo.findById(id.intValue())
+                                .orElseThrow(() -> new ItemNotFoundException("Sale item not found with id: " + id))
+                );
+
+                if (!Objects.equals(saleItem.getSeller().getId(), seller.getId())) {
+                    log.warn("Item ID {} does not belong to seller ID {}. Skipping group.", saleItem.getId(), seller.getId());
+                    throw new IllegalArgumentException("Item ID " + saleItem.getId() + " is not owned by seller ID " + seller.getId());
+                }
+
+                if (saleItem.getQuantity() < itemRequest.getQuantity()) {
+                    hasInsufficientStock = true;
+                    insufficientItemModel = saleItem.getModel();
+                    log.warn("Insufficient stock for item: {} (ID: {}). Required: {}, Available: {}. Canceling order for seller {}.",
+                            saleItem.getModel(), saleItem.getId(), itemRequest.getQuantity(), saleItem.getQuantity(), seller.getId());
+                    break;
+                }
+            }
+
             Order order = new Order();
             order.setBuyer(buyer);
             order.setSeller(seller);
             order.setShippingAddress(req.getShippingAddress());
             order.setOrderNote(req.getOrderNote());
-            order.setOrderStatus(OrderStatus.COMPLETED);
             order.setTotalPrice(BigDecimal.ZERO);
-            for (OrderDto.SelectedCartItem itemRequest : group.getItems()) {
-                SaleItem saleItem = saleItemRepo.findById(itemRequest.getSaleItemId().intValue())
-                        .orElseThrow(() -> new ItemNotFoundException("Sale item not found with id: " + itemRequest.getSaleItemId()));
-                if (!Objects.equals(saleItem.getSeller().getId(), seller.getId())) {
-                    throw new IllegalArgumentException("Item ID " + saleItem.getId() + " is not owned by seller ID " + seller.getId());
-                }
-                if (saleItem.getQuantity() < itemRequest.getQuantity()) {
-                    throw new QuantityNotEnoughException("Not enough stock for item: " + saleItem.getModel());
-                }
-                int updatedRows = saleItemRepo.deductStock(saleItem.getId(), itemRequest.getQuantity());
-                if (updatedRows == 0) {
-                    throw new QuantityNotEnoughException("Failed to deduct stock for item: " + saleItem.getModel());
-                }
-                OrderItem orderItem = new OrderItem();
-                orderItem.setOrder(order);
-                orderItem.setSaleItem(saleItem);
-                orderItem.setPrice(BigDecimal.valueOf(saleItem.getPrice()));
-                orderItem.setQuantity(itemRequest.getQuantity());
-                orderItem.setDescription(saleItem.getModel());
-                order.getItems().add(orderItem);
-                order.setTotalPrice(
-                        order.getTotalPrice().add(orderItem.getPrice().multiply(BigDecimal.valueOf(orderItem.getQuantity())))
-                );
 
-                allSelectedSaleItemIds.add(saleItem.getId());
+            if (hasInsufficientStock) {
+                order.setOrderStatus(OrderStatus.CANCELED);
+                log.info("Order for seller {} is being canceled due to insufficient stock for item: {}", seller.getId(), insufficientItemModel);
+
+                for (OrderDto.SelectedCartItem itemRequest : group.getItems()) {
+                    SaleItem saleItem = fetchedSaleItems.get(itemRequest.getSaleItemId());
+                    if (saleItem == null) continue;
+
+                    OrderItem orderItem = createOrderItemEntity(order, saleItem, itemRequest.getQuantity());
+                    order.getItems().add(orderItem);
+                    // order.setTotalPrice(order.getTotalPrice().add(orderItem.getPrice().multiply(BigDecimal.valueOf(orderItem.getQuantity()))));
+                }
+            } else {
+                order.setOrderStatus(OrderStatus.COMPLETED);
+                log.info("Stock sufficient for seller {}. Proceeding with order.", seller.getId());
+
+                for (OrderDto.SelectedCartItem itemRequest : group.getItems()) {
+                    SaleItem saleItem = fetchedSaleItems.get(itemRequest.getSaleItemId());
+                    if (saleItem == null) continue;
+                    int updatedRows = saleItemRepo.deductStock(saleItem.getId(), itemRequest.getQuantity());
+                    if (updatedRows == 0) {
+                        log.error("Failed to deduct stock for item {} (ID: {}) unexpectedly. Throwing exception.", saleItem.getModel(), saleItem.getId());
+                        throw new QuantityNotEnoughException("Failed to deduct stock for item: " + saleItem.getModel() + " (Possibly due to concurrent update)");
+                    }
+
+                    OrderItem orderItem = createOrderItemEntity(order, saleItem, itemRequest.getQuantity());
+                    order.getItems().add(orderItem);
+
+                    order.setTotalPrice(
+                            order.getTotalPrice().add(orderItem.getPrice().multiply(BigDecimal.valueOf(orderItem.getQuantity())))
+                    );
+
+                    successfullyOrderedSaleItemIds.add(saleItem.getId());
+                }
             }
+
             Order savedOrder = orderRepo.save(order);
+            log.info("Saved order ID {} with status {}", savedOrder.getId(), savedOrder.getOrderStatus());
             responses.add(toPlaceOrderResponseDto(savedOrder));
         }
-        cartRepo.findByBuyerId(buyer.getId())
-                .ifPresent(cart -> {
-                    if (!allSelectedSaleItemIds.isEmpty()) {
-                        cartItemRepo.deleteSelected(cart.getId(), allSelectedSaleItemIds);
-                    }
-                });
+
+        if (!successfullyOrderedSaleItemIds.isEmpty()) {
+            cartRepo.findByBuyerId(buyer.getId())
+                    .ifPresent(cart -> {
+                        log.info("Deleting {} successfully ordered items from cart ID {}", successfullyOrderedSaleItemIds.size(), cart.getId());
+                        cartItemRepo.deleteSelected(cart.getId(), successfullyOrderedSaleItemIds);
+                    });
+        } else {
+            log.info("No items were successfully ordered, skipping cart deletion.");
+        }
+
         return responses;
+    }
+
+    private OrderItem createOrderItemEntity(Order order, SaleItem saleItem, int quantity) {
+        OrderItem orderItem = new OrderItem();
+        orderItem.setOrder(order);
+        orderItem.setSaleItem(saleItem);
+        orderItem.setPrice(BigDecimal.valueOf(saleItem.getPrice()));
+        orderItem.setQuantity(quantity);
+        orderItem.setDescription(saleItem.getModel());
+        return orderItem;
     }
 
     private OrderDto.PlaceOrderResponse toPlaceOrderResponseDto(Order order) {
@@ -137,7 +193,7 @@ public class OrderService {
     public Page<OrderDto.BuyerOrderSummary> getOrdersByBuyer(Integer buyerId, Pageable pageable) {
         Page<Order> orderPage = orderRepo.findByBuyer_IdAndOrderStatusIn(
                 buyerId,
-                List.of(OrderStatus.COMPLETED),
+                List.of(OrderStatus.COMPLETED, OrderStatus.CANCELED),
                 pageable
         );
         return orderPage.map(this::toBuyerOrderSummaryDto);

--- a/frontend/src/components/Pagination/Pagination.vue
+++ b/frontend/src/components/Pagination/Pagination.vue
@@ -3,8 +3,8 @@ import { ref, computed, watch } from "vue";
 
 // Props
 const props = defineProps({
-  currentPage: { type: Number },
-  totalPages: { type: Number },
+	currentPage: { type: Number },
+	totalPages: { type: Number },
 });
 
 // Emit
@@ -12,90 +12,90 @@ const emit = defineEmits(["update:page", "go-to-last"]);
 
 const pageGroupStart = ref(0);
 const goToPage = (page) => {
-  emit("update:page", page);
+	emit("update:page", page);
 
-  if (page < pageGroupStart.value) {
-    pageGroupStart.value = page;
-  } else if (page >= pageGroupStart.value + 10) {
-    pageGroupStart.value = Math.max(0, page - 9);
-  }
+	if (page < pageGroupStart.value) {
+		pageGroupStart.value = page;
+	} else if (page >= pageGroupStart.value + 10) {
+		pageGroupStart.value = Math.max(0, page - 9);
+	}
 };
 const goFirst = () => {
-  emit("update:page", 0);
-  pageGroupStart.value = 0;
+	emit("update:page", 0);
+	pageGroupStart.value = 0;
 };
 const goToLast = () => {
-  emit("go-to-last");
+	emit("go-to-last");
 };
 
 watch(
-  () => props.currentPage,
-  (val) => {
-    if (val < pageGroupStart.value || val >= pageGroupStart.value + 10) {
-      pageGroupStart.value = Math.max(1, val - 4);
-    }
-  },
+	() => props.currentPage,
+	(val) => {
+		if (val < pageGroupStart.value || val >= pageGroupStart.value + 10) {
+			pageGroupStart.value = Math.max(1, val - 4);
+		}
+	}
 );
 const visiblePages = computed(() => {
-  const start = pageGroupStart.value;
-  const end = Math.min(start + 9, props.totalPages - 1);
-  return Array.from({ length: end - start + 1 }, (_, i) => start + i);
+	const start = pageGroupStart.value;
+	const end = Math.min(start + 9, props.totalPages - 1);
+	return Array.from({ length: end - start + 1 }, (_, i) => start + i);
 });
 </script>
 <template>
-  <div
-    v-show="totalPages !== 1"
-    class="mt-6 flex flex-wrap justify-center items-center gap-2 text-sm sm:text-xs md:text-sm"
-  >
-    <!-- First (hidden on mobile) -->
-    <button
-      @click="goFirst()"
-      :disabled="currentPage === 0"
-      class="hidden sm:inline-block itbms-page-first px-3 py-1.5 md:px-3 md:py-1.5 rounded-full border text-gray-700 bg-white hover:bg-gray-100 disabled:opacity-50 disabled:cursor-not-allowed cursor-pointer"
-    >
-      « First
-    </button>
+	<div
+		v-show="totalPages !== 1"
+		class="mt-6 flex flex-wrap justify-center items-center gap-2 text-sm sm:text-xs md:text-sm"
+	>
+		<!-- First (hidden on mobile) -->
+		<button
+			@click="goFirst()"
+			:disabled="currentPage === 0"
+			class="hidden sm:inline-block itbms-page-first px-3 py-1.5 md:px-3 md:py-1.5 rounded-full border text-gray-700 bg-white hover:bg-gray-100 disabled:opacity-50 disabled:cursor-not-allowed cursor-pointer"
+		>
+			« First
+		</button>
 
-    <!-- Prev -->
-    <button
-      @click="goToPage(currentPage - 1)"
-      :disabled="currentPage === 0"
-      class="itbms-page-prev px-2 py-1 sm:px-3 sm:py-1.5 rounded-full border text-gray-700 bg-white hover:bg-gray-100 disabled:opacity-50 disabled:cursor-not-allowed cursor-pointer"
-    >
-      ‹ Prev
-    </button>
+		<!-- Prev -->
+		<button
+			@click="goToPage(currentPage - 1)"
+			:disabled="currentPage === 0"
+			class="itbms-page-prev px-2 py-1 sm:px-3 sm:py-1.5 rounded-full border text-gray-700 bg-white hover:bg-gray-100 disabled:opacity-50 disabled:cursor-not-allowed cursor-pointer"
+		>
+			‹ Prev
+		</button>
 
-    <!-- Page Numbers -->
-    <button
-      v-for="page in visiblePages"
-      :key="page"
-      @click="goToPage(page)"
-      :class="[
-        `itbms-page-${page} px-2 py-1 sm:px-3 sm:py-1.5 rounded-full border cursor-pointer`,
-        page === currentPage
-          ? 'bg-[#171717] text-white font-bold'
-          : 'bg-white text-gray-700 hover:bg-gray-100',
-      ]"
-    >
-      {{ page + 1 }}
-    </button>
+		<!-- Page Numbers -->
+		<button
+			v-for="page in visiblePages"
+			:key="page"
+			@click="goToPage(page)"
+			:class="[
+				`itbms-page-${page} px-2 py-1 sm:px-3 sm:py-1.5 rounded-full border cursor-pointer`,
+				page === currentPage
+					? 'bg-[#171717] text-white font-bold'
+					: 'bg-white text-gray-700 hover:bg-gray-100',
+			]"
+		>
+			{{ page + 1 }}
+		</button>
 
-    <!-- Next -->
-    <button
-      @click="goToPage(currentPage + 1)"
-      :disabled="currentPage + 1 === totalPages"
-      class="itbms-page-next px-2 py-1 sm:px-3 sm:py-1.5 rounded-full border text-gray-700 bg-white hover:bg-gray-100 disabled:opacity-50 disabled:cursor-not-allowed cursor-pointer"
-    >
-      Next ›
-    </button>
+		<!-- Next -->
+		<button
+			@click="goToPage(currentPage + 1)"
+			:disabled="currentPage + 1 === totalPages"
+			class="itbms-page-next px-2 py-1 sm:px-3 sm:py-1.5 rounded-full border text-gray-700 bg-white hover:bg-gray-100 disabled:opacity-50 disabled:cursor-not-allowed cursor-pointer"
+		>
+			Next ›
+		</button>
 
-    <!-- Last (hidden on mobile) -->
-    <button
-      @click="goToPage(totalPages - 1)"
-      :disabled="currentPage + 1 === totalPages"
-      class="hidden sm:inline-block itbms-page-last px-3 py-1.5 md:px-3 md:py-1.5 rounded-full border text-gray-700 bg-white hover:bg-gray-100 disabled:opacity-50 disabled:cursor-not-allowed cursor-pointer"
-    >
-      Last »
-    </button>
-  </div>
+		<!-- Last (hidden on mobile) -->
+		<button
+			@click="goToPage(totalPages - 1)"
+			:disabled="currentPage + 1 === totalPages"
+			class="hidden sm:inline-block itbms-page-last px-3 py-1.5 md:px-3 md:py-1.5 rounded-full border text-gray-700 bg-white hover:bg-gray-100 disabled:opacity-50 disabled:cursor-not-allowed cursor-pointer"
+		>
+			Last »
+		</button>
+	</div>
 </template>

--- a/frontend/src/views/order/YourOrdersView.vue
+++ b/frontend/src/views/order/YourOrdersView.vue
@@ -1,22 +1,22 @@
 <script setup>
-import { ref, onMounted } from "vue";
+import { ref, onMounted, computed, watch } from "vue"; // เพิ่ม computed
 import { useAuthStore } from "@/store/useAuthStore";
 import { fetchOrdersByBuyer } from "@/services/orderService";
 import Pagination from "@/components/Pagination/Pagination.vue";
 
 const auth = useAuthStore();
-const orders = ref([]);
 const pagination = ref({ page: 0, totalPages: 1 });
 const loading = ref(true);
 const error = ref(null);
+const selectedTab = ref("Completed");
+const allOrders = ref([]);
 
-// ฟังก์ชันสำหรับโหลดข้อมูล
 const loadOrders = async (page = 0) => {
 	loading.value = true;
 	error.value = null;
 	try {
 		const response = await fetchOrdersByBuyer(auth.userId, { page });
-		orders.value = response.content;
+		allOrders.value = response.content;
 		pagination.value = {
 			page: response.page,
 			totalPages: response.totalPages,
@@ -28,7 +28,13 @@ const loadOrders = async (page = 0) => {
 	}
 };
 
-// ฟังก์ชันสำหรับจัดรูปแบบวันที่
+const filteredOrders = computed(() => {
+	const statusToFilter = selectedTab.value.toUpperCase();
+	return allOrders.value.filter(
+		(order) => order.orderStatus === statusToFilter
+	);
+});
+
 const formatDate = (isoString) => {
 	if (!isoString) return "-";
 	return new Date(isoString).toLocaleDateString("en-US", {
@@ -38,10 +44,13 @@ const formatDate = (isoString) => {
 	});
 };
 
-// ฟังก์ชันสำหรับจัดรูปแบบตัวเลข
 const formatNumber = (num) => {
 	return Number(num || 0).toLocaleString("en-US");
 };
+
+watch(selectedTab, () => {
+	loadOrders(0);
+});
 
 onMounted(() => {
 	if (auth.isLoggedIn) {
@@ -58,6 +67,33 @@ onMounted(() => {
 		<div class="max-w-4xl mx-auto px-4">
 			<h1 class="text-2xl font-bold text-gray-800 mb-6">Your Orders</h1>
 
+			<div class="mb-6 border-b border-gray-200">
+				<nav class="flex space-x-4" aria-label="Tabs">
+					<button
+						@click="selectedTab = 'Completed'"
+						:class="[
+							'itbms-completed-orders-button px-3 py-2 font-medium text-sm rounded-t-lg',
+							selectedTab === 'Completed'
+								? 'border-b-2 border-blue-600 text-blue-600'
+								: 'text-gray-500 hover:text-gray-700 hover:border-gray-300',
+						]"
+					>
+						Completed
+					</button>
+					<button
+						@click="selectedTab = 'Canceled'"
+						:class="[
+							'itbms-canceled-orders-button px-3 py-2 font-medium text-sm rounded-t-lg',
+							selectedTab === 'Canceled'
+								? 'border-b-2 border-blue-600 text-blue-600'
+								: 'text-gray-500 hover:text-gray-700 hover:border-gray-300',
+						]"
+					>
+						Canceled
+					</button>
+				</nav>
+			</div>
+
 			<div v-if="loading" class="text-center py-10 text-gray-500">
 				Loading your orders...
 			</div>
@@ -70,15 +106,15 @@ onMounted(() => {
 			</div>
 
 			<div
-				v-else-if="orders.length === 0"
+				v-else-if="filteredOrders.length === 0"
 				class="text-center py-10 text-gray-500"
 			>
-				You have no orders yet.
+				You have no {{ selectedTab.toLowerCase() }} orders.
 			</div>
 
 			<div v-else class="space-y-6">
 				<router-link
-					v-for="order in orders"
+					v-for="order in filteredOrders"
 					:key="order.id"
 					:to="`/your-orders/${order.id}`"
 					class="itbms-row block bg-white border border-gray-200 rounded-lg shadow-sm overflow-hidden hover:shadow-md hover:border-blue-300 transition-all duration-200"
@@ -172,12 +208,13 @@ onMounted(() => {
 						</div>
 					</div>
 				</router-link>
-
-				<Pagination
-					:current-page="pagination.page"
-					:total-pages="pagination.totalPages"
-					@update:page="loadOrders"
-				/>
+				<div class="flex flex-col items-center mt-8">
+					<Pagination
+						:current-page="pagination.page"
+						:total-pages="pagination.totalPages"
+						@update:page="loadOrders"
+					/>
+				</div>
 			</div>
 		</div>
 	</div>


### PR DESCRIPTION
feat(order): Implement automatic order cancellation on insufficient stock (PBI-32)

This PR implements the PBI-32 requirement where orders (or parts of orders specific to a seller) are automatically canceled if any requested item quantity exceeds the available stock at the time of placing the order.

**Backend Changes:**

* **OrderService (`placeOrder`):**
    * Added a pre-check loop to validate stock for all items within a `SellerOrderGroup` *before* processing the group.
    * If any item has insufficient stock, the entire `Order` for that specific seller is created with the status `CANCELED`. No stock is deducted for canceled orders.
    * If stock is sufficient for all items in the group, the `Order` is created as `COMPLETED`, and stock is deducted normally.
    * Orders for other sellers within the same `PlaceOrderRequest` are processed independently.
    * Updated cart clearing logic to only remove items from successfully placed (`COMPLETED`) orders.
    * Added logging for stock checks and order status.
* **OrderService (`getOrdersByBuyer`):**
    * Modified to fetch both `COMPLETED` and `CANCELED` orders to support the new frontend tab view.

**Frontend Changes:**

* **YourOrdersView:**
    * Implemented "Completed" and "Canceled" tabs to filter the displayed orders.
    * Added state (`selectedTab`, `allOrders`) and a computed property (`filteredOrders`) for client-side filtering based on `orderStatus`.
    * Modified `loadOrders` to fetch all relevant order statuses from the backend.
    * Updated the template to display orders based on the `filteredOrders` computed property.
    * Added a `watch` effect on `selectedTab` to reset pagination to the first page (`page=0`) when switching tabs, ensuring correct data display. 